### PR TITLE
Create dev.yml

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,35 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+
+    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
+    - name: Update dependency graph
+      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the build process for a Java project using Maven. The workflow is designed to streamline development by setting up a Java environment, caching dependencies, and building the project on pushes and pull requests to the `master` branch.

### New GitHub Actions workflow:
* [`.github/workflows/dev.yml`](diffhunk://#diff-914da273e1d936250929f1160bdd8be46aa865099502b04b471fe734f6b644ddR1-R35): Added a new workflow named "Java CI with Maven" that runs on `ubuntu-latest`. It sets up JDK 17 using the `actions/setup-java` action, caches Maven dependencies, builds the project with Maven, and optionally updates the dependency graph for Dependabot alerts.