### PR TITLE
added gemini api key in dev.yml

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -23,6 +23,7 @@ jobs:
       MAIL_USERNAME: ${{ secrets.MAIL_USERNAME }}
       RAZORPAY_KEY: ${{ secrets.RAZORPAY_KEY }}
       RAZORPAY_SECRET: ${{ secrets.RAZORPAY_SECRET }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/dev.yml` file. The change adds a new environment variable, `GEMINI_API_KEY`, to the `jobs:` section to support integration with the Gemini API.